### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nix-flake-check.yaml
+++ b/.github/workflows/nix-flake-check.yaml
@@ -1,4 +1,6 @@
 name: nix-flake-check
+permissions:
+  contents: read
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/doot/nixos-config/security/code-scanning/5](https://github.com/doot/nixos-config/security/code-scanning/5)

The best fix is to explicitly define a `permissions` block in the workflow file to scope the `GITHUB_TOKEN` privilege to what is strictly necessary. Since the workflow only checks out code and runs a Nix flake check (which does not require pushing code or modifying issues, PRs, etc.), the minimal permission required is `contents: read`. This block should be added either at the workflow (top-level, so it applies to all jobs) or inside the specific job (`check`). Since there is only one job, either is fine, but adding it at the root is clear and prevents future issues if additional jobs are included later.

Required change: add the following block immediately after the `name` field at the root of the workflow YAML file:
```yaml
permissions:
  contents: read
```
No new methods or imports are needed, and the change is limited to a declarative edit in the `.github/workflows/nix-flake-check.yaml` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
