### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -1,4 +1,6 @@
 name: "devenv test"
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/doot/nixos-config/security/code-scanning/4](https://github.com/doot/nixos-config/security/code-scanning/4)

To fix the issue, edit the `.github/workflows/devenv.yml` workflow by adding an explicit `permissions` block. Since the workflow only requires the ability to check out code and run tests (and none of the steps require write access), the minimal sufficient permission is `contents: read`. Place the `permissions` block at the root level of the workflow (just under the workflow `name` and before the `on` block), or specifically at the job level (under `jobs: > tests:`). Setting it at the root ensures all jobs default to least privilege unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
