### PR TITLE
feat: allow hermes agent egress to nix-media-docker

### DIFF
--- a/systems/nix-slopfucker/hermes.nix
+++ b/systems/nix-slopfucker/hermes.nix
@@ -23,7 +23,12 @@
   # To grant a specific host, add its IP, e.g. from the shared constants:
   #   allowedInternalHosts = [ (import ../../common/network.nix).ips.nix-media-docker ];
   # Caveat: per-host (all ports on that host), not per-service.
-  allowedInternalHosts = [];
+  #
+  # nix-media-docker (nmd) is allowed so the agent can reach the self-hosted
+  # Forgejo at git.nmd.jhauschildt.com (its knowledge-base git remote). Per the
+  # caveat above this opens ALL ports on nmd to the agent, not just Forgejo —
+  # an accepted tradeoff until per-service egress (SNI proxy / mesh) exists.
+  allowedInternalHosts = [(import ../../common/network.nix).ips.nix-media-docker];
 
   # Private (RFC1918 / link-local / CGNAT) IPv4 ranges the agent must NOT reach,
   # EXCEPT the allowlisted hosts above. Enforced host-side in the hermes-egress


### PR DESCRIPTION
## Summary

Adds **nix-media-docker (nmd, 192.168.1.88)** to the hermes agent's `allowedInternalHosts`, punching a single reviewable hole in the otherwise default-deny LAN egress wall. This lets the agent reach the self-hosted Forgejo at `git.nmd.jhauschildt.com` — the intended git remote for the agent's knowledge-base vault.

## What changed

`systems/nix-slopfucker/hermes.nix`, one line, using the exact form the existing comment already documents:

```nix
allowedInternalHosts = [(import ../../common/network.nix).ips.nix-media-docker];
```

The host is referenced by name from the shared `common/network.nix` constants — no bare IP string, single source of truth.

## How it works

`allowedInternalHosts` feeds the `hermes-egress` iptables chain, which is evaluated top-to-bottom: allowlisted hosts are `ACCEPT`ed *before* the RFC1918 `DROP`s. Resulting rule:

```
iptables -A hermes-egress -d 192.168.1.88 -j ACCEPT   # before the 192.168.0.0/16 DROP
```

So the agent reaches **nmd only**; the rest of the LAN (gateway, NAS, nsf, other RFC1918) stays blocked. Internet egress is unchanged.

## Security tradeoff (accepted, called out)

Per the lever's own caveat, this is **per-host, not per-service** — it opens **all ports on nmd** to the agent, not just Forgejo's. nmd runs the arion stack (plex, pihole, librenms, freshrss, monitoring) plus navidrome/alloy, so those become reachable too. This is the accepted cost until a per-service egress mechanism (SNI-filtering proxy or a mesh overlay) exists. Documented inline so the tradeoff is a decision, not a surprise.

The rest of the containment is untouched: cap-drop, `nix.enable = false`, ephemeral root, read-only secret bind, and the RFC1918 deny for every other host all remain.

## Verification done

- Branched off pristine `origin/main` (`d9c922e`); single-file, single-line change.
- `alejandra --check` passes.
- Rule generation traced by hand: the new ACCEPT lands ahead of the RFC1918 DROPs, so ACCEPT wins for nmd while the broader `192.168.0.0/16` DROP still covers everything else.

## Not verified here (needs CI / host)

No nix daemon in the agent container, so I could not run `nix flake check` / `nix eval`. After merge + rebuild, confirm host-side with:

```
iptables -L hermes-egress -n   # expect: ACCEPT 192.168.1.88 above the DROP rules
```

and from the container: `curl -sI https://git.nmd.jhauschildt.com` should now connect (it currently times out).

## Follow-ups (not in this PR)

- A Forgejo push credential for the agent (depends on the secrets-management decision still in flight — Bitwarden vs sops/agenix).
- Separately noted: the container can currently reach **public** DNS resolvers directly on :53 (e.g. `dig @8.8.8.8` succeeds), so DNS isn't strictly forced through the host stub. Internal split-horizon names stay private (LAN resolvers are blocked), but this is a DNS-egress hardening item worth its own issue.
