### PR TITLE
feat: add token-authenticated ntfy comms channel for the agent

### DIFF
--- a/systems/nix-media-docker/default.nix
+++ b/systems/nix-media-docker/default.nix
@@ -130,12 +130,33 @@ in {
   services = {
     ntfy-sh = {
       enable = true;
+      # Users (bcrypt hashes) and the agent's access token live ONLY in this
+      # out-of-repo EnvironmentFile (root:root 0600), never committed. It
+      # provisions NTFY_AUTH_USERS + NTFY_AUTH_TOKENS, which the auth-access
+      # ACL below references, so this file must exist before deploy:
+      #   ntfy user hash                          # bcrypt a password (hermes, doot)
+      #   ntfy token generate                     # random tk_... for the agent
+      #   NTFY_AUTH_USERS='hermes:$2a$10$...:user,doot:$2a$10$...:user'
+      #   NTFY_AUTH_TOKENS='hermes:tk_...:agent comms'
+      environmentFile = "/home/doot/secret_test/ntfy/env";
       settings = {
         base-url = "https://ntfy.${fqdn}";
         listen-http = ":2586";
         behind-proxy = true;
         cache-duration = "720h";
         message-size-limit = "32K";
+        # Private instance: deny by default, grant per topic. Users and tokens
+        # come from environmentFile above; this ACL (the authorization
+        # structure) stays in-repo for reviewability — it names no secrets.
+        auth-default-access = "deny-all";
+        auth-access = [
+          # Agent comms channel: agent (token) + phone (password), read-write.
+          "hermes:hermes-agent:rw"
+          "doot:hermes-agent:rw"
+          # Anonymous read-write for the changelog flow: every host's notifier
+          # publishes here and the atom reader on this host polls it.
+          "everyone:nixos-changelog:rw"
+        ];
       };
     };
 

--- a/systems/nix-slopfucker/hermes.nix
+++ b/systems/nix-slopfucker/hermes.nix
@@ -270,12 +270,37 @@ in {
           terminal.cwd = "/var/lib/hermes/workspace";
         };
 
-        # API key lives ONLY in this out-of-repo file (root:root 0600, never
+        # Non-secret wiring for the ntfy gateway platform (a bundled plugin; it
+        # auto-enables as soon as NTFY_TOPIC is present in the env — no
+        # plugins.enabled entry needed). These are deliberately NOT secrets: the
+        # topic name already appears in nmd's ntfy auth-access ACL, so it stays
+        # in-repo where a reviewer can confirm both sides name the same topic.
+        # The access token is the only real secret and lives in agent.env below.
+        #
+        # NTFY_ALLOWED_USERS pins the gateway's inbound allowlist to this topic.
+        # The gateway is fail-CLOSED: the ntfy adapter maps an inbound message's
+        # user_id to the topic name, and with no allowlist set the gateway DROPS
+        # every inbound message rather than fail open. Without this line the
+        # agent could publish OUT but would silently ignore every command IN,
+        # even though the token authenticates fine at the ntfy layer.
+        #
+        # NTFY_TOPIC must match the auth-access entries in
+        # systems/nix-media-docker/default.nix (services.ntfy-sh.settings).
+        environment = {
+          NTFY_SERVER_URL = "https://ntfy.${(import ../../common/network.nix).hosts.nix-media-docker.fqdn}";
+          NTFY_TOPIC = "hermes-agent";
+          NTFY_ALLOWED_USERS = "hermes-agent";
+          NTFY_HOME_CHANNEL = "hermes-agent";
+        };
+
+        # Secrets live ONLY in this out-of-repo file (root:root 0600, never
         # committed), bind-mounted in read-only (shared uids, so container-root
         # reads it as the host root that owns it):
         #   sudo install -d -m 0700 -o root -g root /var/lib/hermes-secrets
         #   sudo install -m 0600 /dev/null /var/lib/hermes-secrets/agent.env
-        #   sudoedit /var/lib/hermes-secrets/agent.env   # COPILOT_GITHUB_TOKEN=...
+        #   sudoedit /var/lib/hermes-secrets/agent.env
+        #     COPILOT_GITHUB_TOKEN=...
+        #     NTFY_TOKEN=tk_...   # matches nmd's NTFY_AUTH_TOKENS for user hermes
         environmentFiles = ["/var/lib/hermes-secrets/agent.env"];
 
         # No compilers or package managers visible to the agent.


### PR DESCRIPTION
## What

Gives the agent a self-hosted, **bidirectional** notification/command channel by wiring the bundled Hermes ntfy gateway plugin to the ntfy server already running on **nmd**, and hardens that server with token auth.

Reachability is unchanged: nmd is **not** WAN-forwarded, so ntfy stays LAN/VPN-only (Option A). This PR adds **app-layer auth on top of the existing network isolation** for defense in depth — so an unauthenticated host *on the LAN* can neither read the agent's replies nor send it commands. That matters because an inbound message is an authoritative instruction to an agent with PR-write + API access; the topic+token is effectively root-over-agent.

## Changes

**ntfy server (`systems/nix-media-docker/default.nix`)**
- `auth-default-access = "deny-all"` + a declarative `auth-access` ACL.
- `hermes` + `doot` get `rw` on the `hermes-agent` topic.
- `everyone:nixos-changelog:rw` preserves the existing changelog flow (see Non-regression).
- Users (bcrypt hashes) + the agent token come from a new out-of-repo `environmentFile`. The ACL names **no secrets** and stays in-repo for review.

**Hermes agent (`systems/nix-slopfucker/hermes.nix`)**
- Non-secret ntfy env (server URL, topic, inbound allowlist, home channel). Plugin auto-enables off `NTFY_TOPIC` — no `plugins.enabled` entry needed.
- `NTFY_ALLOWED_USERS` pinned to the topic name. **The gateway is fail-closed**: the adapter maps an inbound message's `user_id` to the topic name, and with no allowlist set it silently drops every inbound message. Without this line the agent would publish OUT but ignore every command IN.
- `NTFY_TOKEN` (the only real secret) documented for the out-of-repo `agent.env`.

## ⚠️ Non-regression — why the `everyone:nixos-changelog:rw` line exists

`auth-default-access` is **server-global**. `roles.nixos-changelog` defaults `enable = true`, so every host anonymously POSTs upgrade diffs to the `nixos-changelog` topic, and nmd's atom reader anonymously polls it. A bare `deny-all` would break both fleet-wide. The explicit anonymous grant keeps today's behavior. (Tightening the changelog to authenticated is a sensible **follow-up PR** — it touches every host's secret file.)

## 🔧 Out-of-repo prerequisites (NOT in this PR — do before deploy)

1. On **nmd**, create `/home/doot/secret_test/ntfy/env` (root:root 0600):
   ```
   NTFY_AUTH_USERS='hermes:<bcrypt>:user,doot:<bcrypt>:user'
   NTFY_AUTH_TOKENS='hermes:<tk_...>:agent comms'
   ```
   Hashes via \`ntfy user hash\`; token via \`ntfy token generate\`. (This path is already in nmd's borg backup `paths` list.)
2. Append to **nix-slopfucker**'s `/var/lib/hermes-secrets/agent.env`:
   ```
   NTFY_TOKEN=<tk_...>   # same token as NTFY_AUTH_TOKENS above
   ```

## ✅ Verification plan (post-deploy)

1. `ntfy access` on nmd shows the two users + ACL.
2. Anonymous `curl …/hermes-agent/json?poll=1` → **403** (deny-all works).
3. Authenticated agent subscribes; a command round-trips and a reply comes back.
4. Anonymous `curl -d test …/nixos-changelog` → still **200** (no regression).
5. Atom feed still populates on its 15-min timer.

## 🔎 One thing I can't see from the repo

Any ntfy publisher **outside** `nixos-config` (uptime-kuma, Grafana/LibreNMS alerting, home automation, your phone's existing subscriptions) will also hit the global `deny-all`. Worth a glance before deploy — if such consumers exist, they each need an ACL entry or a token.

## Notes
- Identity model: **two identities** (agent token, phone password) for independent revocation. A one-shared-token variant is simpler but loses per-identity revocation — easy to collapse if you'd prefer.
- Validated in-container with `prek run` (alejandra/deadnix/statix passed). Authoritative \`nix flake check\` runs in CI.
- ntfy access tokens grant full *account* access (no per-token scope yet upstream), so the `hermes` user's ACL is deliberately minimal — exactly one topic.