### PR TITLE
fix: wire private sops overlay into nix-slopfucker (import + autoUpgrade override)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -153,6 +153,11 @@
         extraModules = [
           ./systems/nix-slopfucker/proxmox.nix
           hermes-agent.nixosModules.default
+          # Private overlay: the public stub by default; overridden at deploy
+          # (--override-input priv <path>) with the real sops-nix secrets module
+          # that renders the agent's credentials. Without this import the
+          # override has nothing to consume and /run/secrets stays empty.
+          priv.nixosModules.stub
         ];
       };
     };

--- a/systems/nix-slopfucker/default.nix
+++ b/systems/nix-slopfucker/default.nix
@@ -21,6 +21,17 @@
     qemuGuest.enable = true;
   };
 
+  # Layer the private-overlay override onto the common autoUpgrade flags
+  # (listOf str → definitions concatenate, so this appends to common's
+  # ["--refresh" "-L"]). Points priv at the locally-checked-out repo; swap to
+  # the Forgejo URL once that repo is reachable. Without this the host upgrades
+  # against the public stub and the sops secrets never render. Mirrors nmd.
+  system.autoUpgrade.flags = [
+    "--override-input"
+    "priv"
+    "/home/doot/nixos-config-priv"
+  ];
+
   # Isolation: do not join the mesh VPN that bridges this host into the rest of the network.
   # The threat model is capability containment — hermes-agent is treated as hostile code, so
   # we minimise what the VM can reach, not what can reach it.


### PR DESCRIPTION
## Summary

Makes the private sops-nix overlay actually take effect on **nix-slopfucker** (the host running the hermes agent). Two paired changes:

1. **Import the overlay module** — add `priv.nixosModules.stub` to nix-slopfucker's `extraModules` (it was missing; nix-media-docker already has it).
2. **Supply the overlay at deploy** — append `--override-input priv /home/doot/nixos-config-priv` to nix-slopfucker's `autoUpgrade.flags`.

Both are required: (1) makes the module load, (2) makes the deploy swap the public stub for the real secrets overlay. Without either, `/run/secrets` stays empty — which is exactly what was observed.

## Why it was broken

The private-overlay pattern: the public flake imports `priv.nixosModules.stub` (a no-op `_: {}` by default); at deploy the `priv` input is overridden with the real private flake whose `stub` output is aliased to the sops-nix secrets module.

nix-media-docker does both halves already. nix-slopfucker did neither — it was set up before any priv content existed. So even a manual `nixos-rebuild ... --override-input priv ~/nixos-config-priv` swapped the input but nothing imported it → sops-nix never evaluated → no `/run/secrets`.

## Changes

**`flake.nix`** — nix-slopfucker `extraModules`:
```nix
extraModules = [
  ./systems/nix-slopfucker/proxmox.nix
  hermes-agent.nixosModules.default
  priv.nixosModules.stub          # <- added
];
```

**`systems/nix-slopfucker/default.nix`** — append the override to autoUpgrade:
```nix
system.autoUpgrade.flags = [
  "--override-input"
  "priv"
  "/home/doot/nixos-config-priv"
];
```
`autoUpgrade.flags` is `listOf str`, so definitions concatenate — this appends to common's `["--refresh" "-L"]` rather than replacing them. Mirrors nix-media-docker exactly. Points at the local checkout for now; swap to the Forgejo URL once that repo is reachable.

## Verification

- **prek content gates run manually** on both changed files: **alejandra, deadnix, statix — all pass.**
- Both flake eval paths reasoned through:
  - **Image build** (`slop-proxmox`, no override): `priv` = public stub `_: {}`; sops-nix not pulled in; image unaffected.
  - **Deploy** (override active): `stub` → real secrets module; `sops.secrets.*` render to `/run/secrets`.

## Not verified here (concrete blocker)

The agent container has **no nix daemon**, so `nix flake check` / `nix eval` cannot run locally — only structural + formatter checks are possible in-container. Authoritative eval is CI; end-to-end proof is the deploy:

```
sudo nixos-rebuild switch -L --flake ~/nixos-config/ --override-input priv ~/nixos-config-priv
ls -l /run/secrets/     # expect: forgejo-token, copilot-github-token, github-token
```

(The manual `--override-input` on the rebuild command is now also baked into autoUpgrade, so scheduled upgrades pick up the overlay too.)

## Follow-up (separate PR)

Wire the rendered `sops.templates."hermes-agent.env"` into the agent container (bind-mount the `/run` path over the plaintext `/var/lib/hermes-secrets/agent.env`), then retire the plaintext file. Touches `hermes.nix`.
