### PR TITLE
feat: grant agent SSH-only egress to nix-shitfucker for private forgejo

### DIFF
--- a/systems/nix-slopfucker/hermes.nix
+++ b/systems/nix-slopfucker/hermes.nix
@@ -15,30 +15,16 @@
   hermesUid = 994;
   hermesGid = 992;
 
-  # Internal hosts the agent IS allowed to reach, despite the LAN-wide deny
-  # below. Each becomes an ACCEPT in the hermes-egress chain, ahead of the
-  # RFC1918 drops. DEFAULT IS EMPTY — the agent is treated as hostile and must
-  # have zero LAN access unless a host is added here deliberately. (DNS does NOT
-  # require an entry: the container queries systemd-resolved on the veth host
-  # address, and the HOST forwards upstream — it never reaches a LAN resolver.)
-  # To grant a specific host, add its IP, e.g. from the shared constants:
-  #   allowedInternalHosts = [ (import ../../common/network.nix).ips.nix-media-docker ];
-  # Caveat: WHOLE-HOST (all ports). For a single service, prefer the
-  # port-scoped allowedInternalServices below.
-  #
-  # nix-media-docker (nmd) is whole-host because the agent uses several services
-  # on it (Forgejo at git.nmd.jhauschildt.com, ntfy, …). Accepted tradeoff until
-  # every consumer is individually port-scoped.
+  # Internal hosts the agent may reach despite the LAN-wide deny below: each
+  # becomes a whole-host ACCEPT in hermes-egress, ahead of the RFC1918 drops.
+  # DEFAULT EMPTY — the agent is hostile; add hosts deliberately. (DNS needs no
+  # entry; it goes to the host resolver on the veth.) For a single port, prefer
+  # allowedInternalServices below.
+  # nmd is whole-host: the agent uses several of its services (Forgejo, ntfy, …).
   allowedInternalHosts = [(import ../../common/network.nix).ips.nix-media-docker];
 
-  # Port-scoped egress: {host, ports} records granting the agent ONLY the named
-  # TCP ports on that host — tighter than a whole-host entry. Emitted as ACCEPTs
-  # ahead of the RFC1918 drops, same as allowedInternalHosts. Prefer this when
-  # the agent needs exactly one service on a host.
-  #
-  # nix-shitfucker (nsf) hosts the private Forgejo repo (homelab/nixos-config-priv)
-  # the agent pushes secrets-overlay PRs to; it only needs git-over-SSH, so open
-  # TCP 22 alone — the rest of nsf stays denied.
+  # Port-scoped ACCEPTs: {host, ports} grants only those TCP ports on that host.
+  # nsf hosts the private Forgejo repo the agent pushes to — SSH only.
   allowedInternalServices = [
     {
       host = (import ../../common/network.nix).ips.nix-shitfucker;

--- a/systems/nix-slopfucker/hermes.nix
+++ b/systems/nix-slopfucker/hermes.nix
@@ -23,13 +23,28 @@
   # address, and the HOST forwards upstream — it never reaches a LAN resolver.)
   # To grant a specific host, add its IP, e.g. from the shared constants:
   #   allowedInternalHosts = [ (import ../../common/network.nix).ips.nix-media-docker ];
-  # Caveat: per-host (all ports on that host), not per-service.
+  # Caveat: WHOLE-HOST (all ports). For a single service, prefer the
+  # port-scoped allowedInternalServices below.
   #
-  # nix-media-docker (nmd) is allowed so the agent can reach the self-hosted
-  # Forgejo at git.nmd.jhauschildt.com (its knowledge-base git remote). Per the
-  # caveat above this opens ALL ports on nmd to the agent, not just Forgejo —
-  # an accepted tradeoff until per-service egress (SNI proxy / mesh) exists.
+  # nix-media-docker (nmd) is whole-host because the agent uses several services
+  # on it (Forgejo at git.nmd.jhauschildt.com, ntfy, …). Accepted tradeoff until
+  # every consumer is individually port-scoped.
   allowedInternalHosts = [(import ../../common/network.nix).ips.nix-media-docker];
+
+  # Port-scoped egress: {host, ports} records granting the agent ONLY the named
+  # TCP ports on that host — tighter than a whole-host entry. Emitted as ACCEPTs
+  # ahead of the RFC1918 drops, same as allowedInternalHosts. Prefer this when
+  # the agent needs exactly one service on a host.
+  #
+  # nix-shitfucker (nsf) hosts the private Forgejo repo (homelab/nixos-config-priv)
+  # the agent pushes secrets-overlay PRs to; it only needs git-over-SSH, so open
+  # TCP 22 alone — the rest of nsf stays denied.
+  allowedInternalServices = [
+    {
+      host = (import ../../common/network.nix).ips.nix-shitfucker;
+      ports = [22];
+    }
+  ];
 
   # Private (RFC1918 / link-local / CGNAT) IPv4 ranges the agent must NOT reach,
   # EXCEPT the allowlisted hosts above. Enforced host-side in the hermes-egress
@@ -42,11 +57,20 @@
     "100.64.0.0/10" # CGNAT
   ];
 
-  # Body of the `hermes-egress` iptables chain: allow the explicit hosts first,
-  # then deny the private ranges. Evaluated top-to-bottom, so allow wins over
-  # deny; anything not matched falls through to the internet.
+  # Body of the `hermes-egress` iptables chain: allow the explicit hosts and
+  # port-scoped services first, then deny the private ranges. Evaluated
+  # top-to-bottom, so allow wins over deny; anything not matched falls through
+  # to the internet.
   egressRules = lib.concatStringsSep "\n" (
     (map (host: "iptables -A hermes-egress -d ${host} -j ACCEPT") allowedInternalHosts)
+    ++ (lib.concatMap (
+        svc:
+          map (
+            port: "iptables -A hermes-egress -d ${svc.host} -p tcp --dport ${toString port} -j ACCEPT"
+          )
+          svc.ports
+      )
+      allowedInternalServices)
     ++ (map (cidr: "iptables -A hermes-egress -d ${cidr} -j DROP") lanDenyCidrs)
   );
 


### PR DESCRIPTION
## Summary
Add a port-scoped egress primitive (`allowedInternalServices = [{host, ports}]`) and use it to open TCP 22 on nsf (192.168.1.110), so the agent can push to the private Forgejo repo `homelab/nixos-config-priv` over SSH.

## Why
The agent needs git-over-SSH to nsf. Only port 22 is opened — every other nsf port stays behind the RFC1918 deny. Tighter than a whole-host entry (nmd's approach), and it resolves the "per-host, not per-service" caveat the egress block already noted.

## Verify (post-merge)
`iptables -L hermes-egress -n | grep 192.168.1.110` → `ACCEPT tcp dpt:22`
