### PR TITLE
feat: point OBSIDIAN_VAULT_PATH at the hermes-vault clone

### DIFF
--- a/systems/nix-slopfucker/hermes.nix
+++ b/systems/nix-slopfucker/hermes.nix
@@ -281,6 +281,10 @@ in {
           terminal.cwd = "/var/lib/hermes/workspace";
         };
 
+        # Non-secret env for the agent. Points the obsidian skill at the vault
+        # clone (homelab/hermes-vault) so it resolves without a hardcoded path.
+        environment.OBSIDIAN_VAULT_PATH = "/var/lib/hermes/workspace/hermes-vault";
+
         # sops-nix–rendered env file, bind-mounted read-only from the host (see
         # bindMounts above). Decrypted to /run tmpfs (root 0400); values encrypted
         # in the priv overlay (nixos-config-priv/secrets/secrets.yaml).


### PR DESCRIPTION
## Summary
Set `services.hermes-agent.environment.OBSIDIAN_VAULT_PATH` to the vault clone path so the obsidian skill resolves the vault automatically instead of guessing.

## Why
The agent's knowledge base lives in `homelab/hermes-vault`, cloned at `~/workspace/hermes-vault`. `environment` is the module's non-secret env-var option (merged into `$HERMES_HOME/.env` at activation), which is the declarative-correct home for this.
