### PR TITLE
feat: add token-authenticated ntfy comms channel for the agent

### DIFF
--- a/systems/nix-media-docker/default.nix
+++ b/systems/nix-media-docker/default.nix
@@ -130,12 +130,35 @@ in {
   services = {
     ntfy-sh = {
       enable = true;
+      # Users (bcrypt password hashes) and the agent's access token live ONLY in
+      # this out-of-repo EnvironmentFile (root:root 0600, never committed),
+      # matching this host's secret_test convention (readeck/pinchflat/acme). It
+      # provisions NTFY_AUTH_USERS + NTFY_AUTH_TOKENS, which the auth-access ACL
+      # below references, so this file must exist before deploy:
+      #   ntfy user hash                          # bcrypt a password (hermes, doot)
+      #   ntfy token generate                     # random tk_... for the agent
+      #   NTFY_AUTH_USERS='hermes...user'
+      #   NTFY_AUTH_TOKENS='herme...gent comms'
+      environmentFile = "/home/doot/secret_test/ntfy/env";
       settings = {
         base-url = "https://ntfy.${fqdn}";
         listen-http = ":2586";
         behind-proxy = true;
         cache-duration = "720h";
         message-size-limit = "32K";
+        # Private instance: deny by default, grant per topic. Users and tokens
+        # come from environmentFile above; this ACL (the authorization
+        # structure) stays in-repo for reviewability — it names no secrets.
+        auth-default-access = "deny-all";
+        auth-access = [
+          # Agent comms channel: agent (token) + phone (password), read-write.
+          "hermes:hermes-agent:rw"
+          "doot:hermes-agent:rw"
+          # Anonymous read-write for the changelog flow: every host's notifier
+          # publishes here and the atom reader on this host polls it. Without
+          # this explicit grant the server-global deny-all would break it.
+          "everyone:nixos-changelog:rw"
+        ];
       };
     };
 

--- a/systems/nix-media-docker/default.nix
+++ b/systems/nix-media-docker/default.nix
@@ -130,13 +130,8 @@ in {
   services = {
     ntfy-sh = {
       enable = true;
-      # Users (bcrypt password hashes) and the agent's access token live ONLY in
-      # this out-of-repo EnvironmentFile (root:root 0600, never committed),
-      # matching this host's secret_test convention (readeck/pinchflat/acme). It
-      # provisions NTFY_AUTH_USERS + NTFY_AUTH_TOKENS, which the auth-access ACL
-      # below references, so this file must exist before deploy:
-      #   ntfy user hash                          # bcrypt a password (hermes, doot)
-      #   ntfy token generate                     # random tk_... for the agent
+      # Secret env file providing NTFY_AUTH_USERS + NTFY_AUTH_TOKENS. Generate
+      # with `ntfy user hash` (bcrypt) and `ntfy token generate`:
       #   NTFY_AUTH_USERS='hermes...user'
       #   NTFY_AUTH_TOKENS='herme...gent comms'
       environmentFile = "/home/doot/secret_test/ntfy/env";
@@ -147,8 +142,7 @@ in {
         cache-duration = "720h";
         message-size-limit = "32K";
         # Private instance: deny by default, grant per topic. Users and tokens
-        # come from environmentFile above; this ACL (the authorization
-        # structure) stays in-repo for reviewability — it names no secrets.
+        # come from environmentFile above.
         auth-default-access = "deny-all";
         auth-access = [
           # Agent comms channel: agent (token) + phone (password), read-write.

--- a/systems/nix-slopfucker/hermes.nix
+++ b/systems/nix-slopfucker/hermes.nix
@@ -281,13 +281,45 @@ in {
           terminal.cwd = "/var/lib/hermes/workspace";
         };
 
-        # Non-secret env for the agent. Points the obsidian skill at the vault
-        # clone (homelab/hermes-vault) so it resolves without a hardcoded path.
-        environment.OBSIDIAN_VAULT_PATH = "/var/lib/hermes/workspace/hermes-vault";
+        # Non-secret env for the agent, grouped here. Secrets are NOT set here —
+        # they are rendered into agent.env via the sops template (see
+        # environmentFiles below).
+        environment = {
+          # Points the obsidian skill at the vault clone (homelab/hermes-vault)
+          # so it resolves without a hardcoded path.
+          OBSIDIAN_VAULT_PATH = "/var/lib/hermes/workspace/hermes-vault";
+
+          # ntfy comms channel. The bundled ntfy gateway plugin auto-enables as
+          # soon as NTFY_TOPIC is in the env — no plugins.enabled entry needed.
+          # These are deliberately NOT secrets: the topic name already appears in
+          # nmd's ntfy auth-access ACL, so it stays in-repo where a reviewer can
+          # confirm both sides name the same topic. The access token is the only
+          # real secret and is rendered via the sops template (environmentFiles).
+          #
+          # NTFY_ALLOWED_USERS pins the gateway's inbound allowlist to this
+          # topic. The gateway is fail-CLOSED: the ntfy adapter maps an inbound
+          # message's user_id to the topic name, and with no allowlist set the
+          # gateway DROPS every inbound message rather than fail open. Without
+          # this line the agent could publish OUT but would silently ignore
+          # every command IN, even though the token authenticates fine.
+          #
+          # NTFY_TOPIC must match the auth-access entries in
+          # systems/nix-media-docker/default.nix (services.ntfy-sh.settings).
+          NTFY_SERVER_URL = "https://ntfy.${(import ../../common/network.nix).hosts.nix-media-docker.fqdn}";
+          NTFY_TOPIC = "hermes-agent";
+          NTFY_ALLOWED_USERS = "hermes-agent";
+          NTFY_HOME_CHANNEL = "hermes-agent";
+        };
 
         # sops-nix–rendered env file, bind-mounted read-only from the host (see
         # bindMounts above). Decrypted to /run tmpfs (root 0400); values encrypted
         # in the priv overlay (nixos-config-priv/secrets/secrets.yaml).
+        #
+        # For the ntfy channel, add NTFY_TOKEN to the "hermes-agent.env" sops
+        # template in the priv overlay (alongside COPILOT_GITHUB_TOKEN): encrypt
+        # the value as a new sops secret and reference it via
+        # config.sops.placeholder in the template. It must equal the tk_... in
+        # nmd's NTFY_AUTH_TOKENS for user hermes.
         environmentFiles = ["/var/lib/hermes-secrets/agent.env"];
 
         # No compilers or package managers visible to the agent.

--- a/systems/nix-slopfucker/hermes.nix
+++ b/systems/nix-slopfucker/hermes.nix
@@ -281,30 +281,20 @@ in {
           terminal.cwd = "/var/lib/hermes/workspace";
         };
 
-        # Non-secret env for the agent, grouped here. Secrets are NOT set here —
-        # they are rendered into agent.env via the sops template (see
-        # environmentFiles below).
+        # Non-secret env for the agent.
         environment = {
           # Points the obsidian skill at the vault clone (homelab/hermes-vault)
           # so it resolves without a hardcoded path.
           OBSIDIAN_VAULT_PATH = "/var/lib/hermes/workspace/hermes-vault";
 
-          # ntfy comms channel. The bundled ntfy gateway plugin auto-enables as
-          # soon as NTFY_TOPIC is in the env — no plugins.enabled entry needed.
-          # These are deliberately NOT secrets: the topic name already appears in
-          # nmd's ntfy auth-access ACL, so it stays in-repo where a reviewer can
-          # confirm both sides name the same topic. The access token is the only
-          # real secret and is rendered via the sops template (environmentFiles).
+          # ntfy comms channel. The bundled ntfy plugin auto-enables once
+          # NTFY_TOPIC is set; the token (the only secret) comes from the sops
+          # template. NTFY_TOPIC must match nmd's auth-access ACL
+          # (systems/nix-media-docker/default.nix).
           #
-          # NTFY_ALLOWED_USERS pins the gateway's inbound allowlist to this
-          # topic. The gateway is fail-CLOSED: the ntfy adapter maps an inbound
-          # message's user_id to the topic name, and with no allowlist set the
-          # gateway DROPS every inbound message rather than fail open. Without
-          # this line the agent could publish OUT but would silently ignore
-          # every command IN, even though the token authenticates fine.
-          #
-          # NTFY_TOPIC must match the auth-access entries in
-          # systems/nix-media-docker/default.nix (services.ntfy-sh.settings).
+          # NTFY_ALLOWED_USERS is required: the gateway is fail-closed and the
+          # ntfy adapter keys inbound identity on the topic name, so without it
+          # every inbound message is dropped (outbound still works).
           NTFY_SERVER_URL = "https://ntfy.${(import ../../common/network.nix).hosts.nix-media-docker.fqdn}";
           NTFY_TOPIC = "hermes-agent";
           NTFY_ALLOWED_USERS = "hermes-agent";
@@ -315,10 +305,8 @@ in {
         # bindMounts above). Decrypted to /run tmpfs (root 0400); values encrypted
         # in the priv overlay (nixos-config-priv/secrets/secrets.yaml).
         #
-        # For the ntfy channel, add NTFY_TOKEN to the "hermes-agent.env" sops
-        # template in the priv overlay (alongside COPILOT_GITHUB_TOKEN): encrypt
-        # the value as a new sops secret and reference it via
-        # config.sops.placeholder in the template. It must equal the tk_... in
+        # For ntfy, add NTFY_TOKEN to the "hermes-agent.env" sops template in the
+        # priv overlay (via config.sops.placeholder); it must equal the tk_... in
         # nmd's NTFY_AUTH_TOKENS for user hermes.
         environmentFiles = ["/var/lib/hermes-secrets/agent.env"];
 


### PR DESCRIPTION
Supersedes #773 (rebuilt on current main after the sops-nix migration).

## Summary

Wires the bundled Hermes ntfy gateway plugin to the ntfy server on nmd, giving the agent a self-hosted bidirectional notification/command channel, and hardens the server with token auth. nmd isn't WAN-forwarded, so ntfy stays LAN/VPN-only; this adds app-layer auth on top for defense in depth — an unauthenticated LAN host can neither read the agent's replies nor command it.

## Changes

ntfy (systems/nix-media-docker/default.nix)
- auth-default-access = deny-all + a declarative auth-access ACL granting hermes + doot rw on the hermes-agent topic.
- everyone:nixos-changelog:rw keeps the existing anonymous changelog flow working under deny-all (which is server-global).
- Users/token come from an out-of-repo environmentFile, matching this host's secret_test convention.

agent (systems/nix-slopfucker/hermes.nix)
- ntfy env folded into the existing environment block; the plugin auto-enables off NTFY_TOPIC.
- NTFY_ALLOWED_USERS pinned to the topic — the gateway is fail-closed, so without it inbound messages are silently dropped.
- NTFY_TOKEN lives in the hermes-agent.env sops template (priv overlay), not committed.

## Deploy prerequisites (out-of-repo)

1. [done] nmd /home/doot/secret_test/ntfy/env — NTFY_AUTH_USERS (ntfy user hash) + NTFY_AUTH_TOKENS (ntfy token generate).
2. Add NTFY_TOKEN to the hermes-agent.env sops template (priv overlay); same tk_ value as nmd's NTFY_AUTH_TOKENS for user hermes.

## Verify (post-deploy)

- anon `curl .../hermes-agent/json?poll=1` -> 403
- authenticated agent round-trips a command
- anon `curl -d test .../nixos-changelog` -> 200 (changelog still works)

Note: deny-all is server-global, so any ntfy publisher outside nixos-config (uptime-kuma, Grafana/LibreNMS, phone subscriptions) also needs a token or ACL entry.