### PR TITLE
feat: declarative SOUL.md identity for the hermes agent

### DIFF
--- a/priv/flake.nix
+++ b/priv/flake.nix
@@ -10,5 +10,9 @@
     nixpkgs,
   }: {
     nixosModules.stub = _: {};
+    # No-op counterpart to the private overlay's hermesSoul module. Present so
+    # the public flake evaluates (nix flake check) with the stub priv input;
+    # the real module that lands SOUL.md is swapped in via --override-input priv.
+    nixosModules.hermesSoul = _: {};
   };
 }

--- a/priv/flake.nix
+++ b/priv/flake.nix
@@ -10,9 +10,6 @@
     nixpkgs,
   }: {
     nixosModules.stub = _: {};
-    # No-op counterpart to the private overlay's hermesSoul module. Present so
-    # the public flake evaluates (nix flake check) with the stub priv input;
-    # the real module that lands SOUL.md is swapped in via --override-input priv.
-    nixosModules.hermesSoul = _: {};
+    nixosModules.hermesPriv = _: {};
   };
 }

--- a/systems/nix-slopfucker/hermes.nix
+++ b/systems/nix-slopfucker/hermes.nix
@@ -188,7 +188,14 @@ in {
       hermesGid,
       ...
     }: {
-      imports = [inputs.hermes-agent.nixosModules.default];
+      imports = [
+        inputs.hermes-agent.nixosModules.default
+        # Declarative agent identity (SOUL.md). Resolves to a no-op stub in the
+        # public flake; the real module — which lands the private soul content
+        # into the container's $HERMES_HOME — is swapped in at deploy via the
+        # same --override-input priv that supplies the sops secrets.
+        inputs.priv.nixosModules.hermesSoul
+      ];
 
       # Pin the container's hermes user/group to the SAME ids as the host's
       # (threaded in via specialArgs above). The hermes-agent module declares

--- a/systems/nix-slopfucker/hermes.nix
+++ b/systems/nix-slopfucker/hermes.nix
@@ -190,11 +190,7 @@ in {
     }: {
       imports = [
         inputs.hermes-agent.nixosModules.default
-        # Declarative agent identity (SOUL.md). Resolves to a no-op stub in the
-        # public flake; the real module — which lands the private soul content
-        # into the container's $HERMES_HOME — is swapped in at deploy via the
-        # same --override-input priv that supplies the sops secrets.
-        inputs.priv.nixosModules.hermesSoul
+        inputs.priv.nixosModules.hermesPriv
       ];
 
       # Pin the container's hermes user/group to the SAME ids as the host's


### PR DESCRIPTION
## Summary

Makes the agent's `SOUL.md` declarative, sourced from the private overlay, replacing the untracked hand-placed file in `$HERMES_HOME` (mutable local state). This is the public half; the content + real module live in the `nixos-config-priv` PR.

## Changes

- `systems/nix-slopfucker/hermes.nix` — import `inputs.priv.nixosModules.hermesPriv` into the container config. Applied only when `--override-input priv` swaps in the real overlay (same seam as the sops secrets).
- `priv/flake.nix` — no-op `hermesPriv` stub so the public flake evaluates with the stub `priv` input.

## Notes

- SOUL.md is read only from `$HERMES_HOME`; the module lands it there via tmpfiles (the `documents` option targets `workingDirectory`, which is not read as identity).
- The real module symlinks to the read-only store, so the agent cannot self-edit its charter — the soul changes by PR + rebuild.
- CI runs `nix flake check --override-input priv ./priv`, so no `flake.lock` bump is needed.