### PR TITLE
fix: disable nginx proxy buffering on the ntfy stream vhost

### DIFF
--- a/systems/nix-media-docker/default.nix
+++ b/systems/nix-media-docker/default.nix
@@ -344,6 +344,13 @@ in {
         {
           name = "ntfy";
           port = 2586;
+          # ntfy's subscribe stream is a long-lived chunked response; default
+          # proxy_buffering withholds it from HTTP/1.1 clients (the agent), and a
+          # long read timeout stops nginx cutting the idle-but-alive stream.
+          extraConfig = ''
+            proxy_buffering off;
+            proxy_read_timeout 3600s;
+          '';
         }
         # {
         #   name = "gitea-mirror";


### PR DESCRIPTION
## Summary

Follow-up to the ntfy comms channel (#791): the inbound half was broken on deploy. This fixes it.

After deploy, the agent's ntfy subscriber connected once then fell into an endless reconnect loop — `Stream error:` (empty) every ~92s in gateway.log. Diagnosed to nginx buffering the ntfy subscribe stream for HTTP/1.1 clients.

## Root cause (proven, not guessed)

ntfy's subscribe stream (`/json?poll=false`) is a long-lived chunked HTTP response emitting a keepalive every ~45s. With nginx's default `proxy_buffering on`, that stream is withheld from **HTTP/1.1** clients while **HTTP/2** clients get it fine.

The agent's httpx subscriber speaks HTTP/1.1 (no `h2` package in the env), so it received zero bytes — not even response headers — and hit its 90s read timeout every cycle (90s timeout + 2s backoff = the observed 92s cadence).

Control experiment that nails it, same URL + token from the agent's container:
- `curl -sN` (HTTP/2 by default over TLS): streams `open` + keepalives, survives past 90s. ✅
- `curl -sN --http1.1`: **zero output for 100s** — reproduces the exact hang. ✅
- httpx `.stream()` (HTTP/1.1): `ReadTimeout('')`, no headers, even via `aiter_raw()`. ✅

Ruled out: auth (poll=1 non-stream returns 200), gzip (forcing `Accept-Encoding: identity` didn't help), client line-buffering (raw bytes also empty).

## Fix

`proxy_buffering off` + a long `proxy_read_timeout` on the ntfy vhost only (via the nginx-proxy module's per-proxy extraConfig), so the stream passes straight through and idle-but-alive connections aren't cut. No other vhost affected.

## What was already verified working (unchanged by this PR)
- Auth boundary: anon read of hermes-agent → 403; authenticated → 200.
- Non-regression: anon publish to nixos-changelog → 200.
- Outbound publish (agent → ntfy POST) → 200, message lands.

## Verify after deploy
- `curl -sN --http1.1 -H "Authorization: Bearer <token>" https://ntfy.nmd.jhauschildt.com/hermes-agent/json?poll=false` streams `open` + keepalives immediately (currently hangs).
- gateway.log: the `[Ntfy] Stream error` / `Reconnecting` loop stops; connection stays up.
- Full round-trip: publish a message to the hermes-agent topic and confirm the agent receives it inbound.