### PR TITLE
fix(borg): whitelist preHook dump dir so nsf offsite backup stops failing

### DIFF
--- a/modules/borg/default.nix
+++ b/modules/borg/default.nix
@@ -33,11 +33,24 @@ in {
       default = "";
       description = "Shell run before the backup, e.g. to dump databases into a staging dir that is also listed in `paths`.";
     };
+
+    readWritePaths = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
+      default = [];
+      description = ''
+        Directories the backup service is allowed to write to. The nixpkgs
+        borgbackup module runs the job under `ProtectSystem = "strict"`, so the
+        whole filesystem is read-only except borg's own cache/config. Any path a
+        `preHook` writes to (e.g. a DB-dump staging dir) MUST be listed here or
+        the preHook fails with "Read-only file system".
+      '';
+      example = ["/var/backup/mysqldump"];
+    };
   };
 
   config = lib.mkIf cfg.enable {
     services.borgbackup.jobs.${cfg.jobName} = {
-      inherit (cfg) paths repo preHook;
+      inherit (cfg) paths repo preHook readWritePaths;
       archiveBaseName = cfg.jobName;
       # TODO(secrets): switch to repokey encryption with a passphrase sourced from the
       # secrets store once that task lands. Unencrypted matches the current posture.

--- a/systems/nix-shitfucker/default.nix
+++ b/systems/nix-shitfucker/default.nix
@@ -169,6 +169,11 @@
     ];
   };
 
+  # Pre-create the immich dump staging dir: the borg job (root) writes here in
+  # its preHook, and systemd requires every ReadWritePaths entry to exist before
+  # the unit starts.
+  systemd.tmpfiles.rules = ["d /var/backup/immich 0700 root root -"];
+
   roles = {
     # Enable forgejo service
     forgejo.enable = true;
@@ -184,10 +189,11 @@
         "/var/lib/nextcloud" # nextcloud data + sqlite DB
         "/var/backup/immich" # immich Postgres dump written by preHook below
       ];
-      # The nixpkgs borgbackup module runs under ProtectSystem=strict, so the
-      # preHook cannot create /var/backup/immich unless it is whitelisted here.
-      # Without this the whole job hard-fails ("Read-only file system").
-      readWritePaths = ["/var/backup"];
+      # ProtectSystem=strict makes the FS read-only, so the preHook's dump dir
+      # must be whitelisted. systemd also requires the path to already exist, and
+      # the borg module only tmpfiles-creates its own cache/config — hence the
+      # tmpfiles rule below.
+      readWritePaths = ["/var/backup/immich"];
       # Immich uses Postgres, so a live file copy would be inconsistent — dump it instead.
       # forgejo/nextcloud are sqlite and backed up at the file level (same approach as nmd's
       # other sqlite services); point-in-time, with the usual live-sqlite caveat.

--- a/systems/nix-shitfucker/default.nix
+++ b/systems/nix-shitfucker/default.nix
@@ -184,6 +184,10 @@
         "/var/lib/nextcloud" # nextcloud data + sqlite DB
         "/var/backup/immich" # immich Postgres dump written by preHook below
       ];
+      # The nixpkgs borgbackup module runs under ProtectSystem=strict, so the
+      # preHook cannot create /var/backup/immich unless it is whitelisted here.
+      # Without this the whole job hard-fails ("Read-only file system").
+      readWritePaths = ["/var/backup"];
       # Immich uses Postgres, so a live file copy would be inconsistent — dump it instead.
       # forgejo/nextcloud are sqlite and backed up at the file level (same approach as nmd's
       # other sqlite services); point-in-time, with the usual live-sqlite caveat.


### PR DESCRIPTION
## Problem
`borgbackup-job-borg-nsf.service` on **nix-shitfucker** has been **failed** since the job was added (`679a6dc`, ~24+ days). The offsite backup of **forgejo, nextcloud, and immich** has never successfully run.

## Root cause
The nixpkgs `borgbackup` module runs jobs under `ProtectSystem = "strict"` — whole FS read-only except borg's cache/config + `readWritePaths`. nsf's `preHook` dumps immich's Postgres into `/var/backup/immich`, so `install -d` dies with `Read-only file system` and the unit hard-fails.

## Fix (two parts — the dir must exist *and* be writable)
1. Expose the module's `readWritePaths` passthrough (upstream borgbackup option).
2. On nsf: **pre-create** `/var/backup/immich` via `systemd.tmpfiles` (systemd requires every `ReadWritePaths` target to exist before start, and the borg module only tmpfiles-creates its own cache/config) and whitelist that exact dir.

## Evidence
- Loki `{unit="borgbackup-job-borg-nsf.service"}`: `install: cannot create directory '/var/backup': Read-only file system`, daily for ~30 days.
- `node_systemd_unit_state{name="borgbackup-job-borg-nsf.service",state="failed"} = 1` (still red).
- `node_filesystem_readonly{instance="nsf...",mountpoint="/"} = 0` → RO is the sandbox, not the disk.

## Notes
- Found by the daily health-watch cron. Gates green locally: alejandra, deadnix, statix.
- nmd's borg survives the same trap only because its preHook ends in `|| true` (silently skips its dump) — latent, worth a separate look.
