### PR TITLE
fix(borg): tolerate live-file warnings on nmd's backup

### DIFF
--- a/modules/borg/default.nix
+++ b/modules/borg/default.nix
@@ -33,11 +33,22 @@ in {
       default = "";
       description = "Shell run before the backup, e.g. to dump databases into a staging dir that is also listed in `paths`.";
     };
+
+    failOnWarnings = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Fail the job on a borg warning (exit 1). Keep true so a warning is a
+        real signal; set false only for a job that backs up files written live
+        (e.g. an sqlite DB), where "file changed while we backed it up" is
+        expected and would otherwise mark every run failed.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
     services.borgbackup.jobs.${cfg.jobName} = {
-      inherit (cfg) paths repo preHook;
+      inherit (cfg) paths repo preHook failOnWarnings;
       archiveBaseName = cfg.jobName;
       # TODO(secrets): switch to repokey encryption with a passphrase sourced from the
       # secrets store once that task lands. Unencrypted matches the current posture.

--- a/systems/nix-media-docker/default.nix
+++ b/systems/nix-media-docker/default.nix
@@ -219,6 +219,10 @@ in {
       enable = true;
       jobName = "borg-nmd";
       repo = "ssh://proxmox-borg@192.168.1.60:2222/volume1/proxmox-nfs/borg-nmd";
+      # freshrss/grafana/etc. sqlite DBs are copied live, so borg warns "file
+      # changed while we backed it up" (exit 1) and every run is marked failed
+      # even though the archive uploads fine. Tolerate the warning here.
+      failOnWarnings = false;
       paths = [
         "/var/lib/karakeep"
         "/var/lib/grafana/data"


### PR DESCRIPTION
## Problem
`borgbackup-job-borg-nmd.service` on **nix-media-docker** goes **failed** every night — but the data is fine. The archive uploads (~6 GB), it's just marked `.failed` and the unit reports failure.

## Root cause (verified via Loki + pinned nixpkgs module)
nmd backs up live sqlite DBs (freshrss and others) at the file level. Loki shows:
```
/docker-local/freshrss/.../db.sqlite: file changed while we backed it up
```
That's a borg **warning** (exit 1). The nixpkgs borgbackup module defaults `failOnWarnings = true`, so its `borgWrapper` propagates rc 1, the job fails, and the `.failed`→clean archive rename never runs. So every run leaves a `.failed` archive and a red unit, despite a complete upload.

(The `preHook`'s `find … || true` is unrelated — it protects a file-listing step, not a DB dump.)

## Fix
Expose `failOnWarnings` on `roles.borg` (default **true** — strict everywhere), and set it **false** for nmd so an *expected* live-file warning stops masking a working backup.

## Alternative considered (deferred — needs host access to do safely)
The stricter fix is to dump each sqlite DB to a consistent staging file in `preHook` (`sqlite3 <db> ".backup <staging>"`), back up the dump instead of the live file, and keep `failOnWarnings = true` as a real signal — the same shape as nsf's immich Postgres dump. I did **not** do that here: the exact on-disk DB paths/owners (freshrss runs in docker with per-user DBs; grafana/karakeep/actual) can't be verified from the agent's sealed container, and a wrong dump path would break the whole backup. Happy to do it as a follow-up with your input on the paths.

## Note
Once #796 unblocks nsf's borg, nsf will likely hit the same live-sqlite warning on forgejo/nextcloud — worth applying the same lever (or dumps) there.

Gates green locally: alejandra, deadnix, statix.
