### PR TITLE
feat(borg): deploy shared borg SSH key via sops on the backup hosts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -124,6 +124,7 @@
           ./common/monitoring
           arion.nixosModules.arion
           priv.nixosModules.stub
+          priv.nixosModules.borgKey
         ];
       };
 
@@ -134,6 +135,7 @@
         extraModules = [
           ./common/sunshine
           ./systems/nix-shitfucker/proxmox.nix
+          priv.nixosModules.borgKey
           home-manager.nixosModules.home-manager
           {
             home-manager = {

--- a/modules/borg/default.nix
+++ b/modules/borg/default.nix
@@ -66,7 +66,7 @@ in {
       # TODO(secrets): switch to repokey encryption with a passphrase sourced from the
       # secrets store once that task lands. Unencrypted matches the current posture.
       encryption.mode = "none";
-      environment.BORG_RSH = "ssh -o 'StrictHostKeyChecking=no' -o 'BatchMode=yes' -i /root/.ssh/id_ed25519";
+      environment.BORG_RSH = "ssh -o 'StrictHostKeyChecking=no' -o 'BatchMode=yes' -i /root/.ssh/borg_ed25519";
       extraArgs = ["--remote-path=/usr/local/bin/borg"];
       extraCreateArgs = [
         "--stats"

--- a/priv/flake.nix
+++ b/priv/flake.nix
@@ -9,7 +9,10 @@
     # deadnix: skip
     nixpkgs,
   }: {
-    nixosModules.stub = _: {};
-    nixosModules.hermesPriv = _: {};
+    nixosModules = {
+      stub = _: {};
+      hermesPriv = _: {};
+      borgKey = _: {};
+    };
   };
 }

--- a/systems/nix-shitfucker/default.nix
+++ b/systems/nix-shitfucker/default.nix
@@ -56,12 +56,12 @@
   system.stateVersion = "23.11";
 
   # Append the private-overlay override so scheduled auto-upgrades render the
-  # sops borg key (concatenates with common's ["--refresh" "-L"]). Without this
-  # nsf upgrades against the public stub and borgKey is a no-op. Mirrors nmd.
+  # sops borg key (concatenates with common's ["--refresh" "-L"]). Fetched from
+  # Forgejo over git+ssh (see common/default.nix ssh config). Mirrors nmd.
   system.autoUpgrade.flags = [
     "--override-input"
     "priv"
-    "/home/doot/nixos-config-priv"
+    "git+ssh://forgejo@nsf.jhauschildt.com/homelab/nixos-config-priv.git?ref=main"
   ];
 
   services = {

--- a/systems/nix-shitfucker/default.nix
+++ b/systems/nix-shitfucker/default.nix
@@ -55,6 +55,15 @@
 
   system.stateVersion = "23.11";
 
+  # Append the private-overlay override so scheduled auto-upgrades render the
+  # sops borg key (concatenates with common's ["--refresh" "-L"]). Without this
+  # nsf upgrades against the public stub and borgKey is a no-op. Mirrors nmd.
+  system.autoUpgrade.flags = [
+    "--override-input"
+    "priv"
+    "/home/doot/nixos-config-priv"
+  ];
+
   services = {
     qemuGuest.enable = true;
 


### PR DESCRIPTION
## What
Deploy a single shared borg SSH key to the backup hosts (nsf, nmd) declaratively via the priv sops overlay, replacing the hand-placed `/root/.ssh/id_ed25519` that borg was using.

- New `priv.nixosModules.borgKey` renders the key to a **dedicated** `/root/.ssh/borg_ed25519` (never collides with a host's root login key).
- Imported on nsf + nmd; `BORG_RSH` points at the new path.
- Public priv stub gains a `borgKey` no-op so CI (`--override-input priv ./priv`) still evaluates.

## Why
nsf's borg was failing SSH auth to the NAS because its key was never authorized there — a hand-placed, undeclared key that drifted. This brings the borg identity under sops so it's reproducible on every host and can't silently drift again. Adopts the existing (already-NAS-authorized) nmd key, so **zero NAS-side change** and backups stay green.

## Deploy ordering (IMPORTANT)
Requires the matching **priv-overlay** change (`homelab/nixos-config-priv` branch `feat/borg-key-sops`): fill the nsf/nmd host-key recipients in `.sops.yaml`, then create `secrets/borg.yaml` with the adopted key. **Deploy priv-first** — a `sops.secrets."borg-ssh-key"` with no ciphertext fails at activation. Merge/deploy priv, then merge this.

## Verification
- Gates green locally: alejandra, deadnix, statix.
- Eval against the stub is reasoned but not locally run (no nix in the agent container) — relying on CI's `nix flake check` here.
