### PR TITLE
feat(priv): fetch private overlay from Forgejo over git+ssh

### DIFF
--- a/common/default.nix
+++ b/common/default.nix
@@ -121,6 +121,21 @@ in {
   programs = {
     git.enable = true;
     direnv.enable = true;
+
+    # Let root's nixos-rebuild fetch the private priv overlay from Forgejo over
+    # git+ssh non-interactively: pin the host key (no prompt) and present the
+    # host's own SSH key, which is authorized as a read-only deploy key on the
+    # repo. Reuses "secret zero" — no new credential.
+    ssh = {
+      knownHosts."nsf-forgejo" = {
+        hostNames = ["nsf.jhauschildt.com"];
+        publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGEm1zOqhceutFGxtW6IYryiP9GH/XpgM2aqfpf7H8FH";
+      };
+      extraConfig = ''
+        Host nsf.jhauschildt.com
+          IdentityFile /etc/ssh/ssh_host_ed25519_key
+      '';
+    };
     bash.completion.enable = true;
     fzf = {
       keybindings = true;

--- a/systems/nix-media-docker/default.nix
+++ b/systems/nix-media-docker/default.nix
@@ -28,7 +28,7 @@ in {
       flags = [
         "--override-input"
         "priv"
-        "/home/doot/nixos-config-priv"
+        "git+ssh://forgejo@nsf.jhauschildt.com/homelab/nixos-config-priv.git?ref=main"
       ];
 
       # This system is in lxc container, so it will never have kernel upgrades. All upgrades fail when this is enabled due to trying to read boot symlinks that don't exist.


### PR DESCRIPTION
## Problem
The `priv` override points at a local checkout (`/home/doot/nixos-config-priv`) that only exists on machines where the private repo was manually cloned. It is **not** on the backup hosts, so `priv.nixosModules.borgKey` (and any priv content) silently stays the public no-op stub — the sops borg key never renders.

## Fix
Point the override at the private Forgejo repo over `git+ssh`, and let root's `nixos-rebuild` authenticate with the host's **own** SSH host key — authorized as a **read-only deploy key** on the repo. This reuses "secret zero" (the key already on every host, same one sops-nix decrypts with) — no new credential enters config or the nix store.

- `common/default.nix`: `programs.ssh.knownHosts` pins the Forgejo host key (non-interactive fetch) + `IdentityFile /etc/ssh/ssh_host_ed25519_key` for that host.
- `nix-media-docker`: override URL → `git+ssh://forgejo@nsf.jhauschildt.com/homelab/nixos-config-priv.git?ref=main`.
- nsf gets the same URL in #804.

## DEPLOY ORDER (required — read before merging)
Before the next rebuild on each host, authorize that host's public key as a **read-only deploy key** on `homelab/nixos-config-priv`:
```
# on each host:
cat /etc/ssh/ssh_host_ed25519_key.pub
# paste into Forgejo → repo Settings → Deploy Keys (read-only) on nixos-config-priv
```
If skipped, the git+ssh fetch fails and the rebuild aborts. **nmd currently works via the local checkout** — switching it to git+ssh means nmd also needs its deploy key authorized first. Suggest deploying one host manually (`nixos-rebuild ... --override-input priv <url>`) to confirm the fetch before letting auto-upgrade run.

## Verification
- Gates green locally: alejandra, deadnix, statix.
- CI `nix flake check` evaluates against the public stub (override only applies at deploy) — the fetch itself can only be verified on-host.
