### PR TITLE
refactor(priv): import a per-host private bundle on each host

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -123,8 +123,10 @@
         extraModules = [
           ./common/monitoring
           arion.nixosModules.arion
-          priv.nixosModules.stub
-          priv.nixosModules.borgKey
+          # Private overlay bundle for this host: sops bootstrap + borg key +
+          # nmd's own services. Excludes the agent credentials, which slop alone
+          # is a sops recipient of.
+          priv.nixosModules.nmdPriv
         ];
       };
 
@@ -135,7 +137,7 @@
         extraModules = [
           ./common/sunshine
           ./systems/nix-shitfucker/proxmox.nix
-          priv.nixosModules.borgKey
+          priv.nixosModules.nsfPriv
           home-manager.nixosModules.home-manager
           {
             home-manager = {
@@ -155,11 +157,11 @@
         extraModules = [
           ./systems/nix-slopfucker/proxmox.nix
           hermes-agent.nixosModules.default
-          # Private overlay: the public stub by default; overridden at deploy
-          # (--override-input priv <path>) with the real sops-nix secrets module
-          # that renders the agent's credentials. Without this import the
-          # override has nothing to consume and /run/secrets stays empty.
-          priv.nixosModules.stub
+          # Private overlay bundle for this host: sops bootstrap + the agent's
+          # credentials. Overridden at deploy (--override-input priv <url>);
+          # without this import the override has nothing to consume and
+          # /run/secrets stays empty.
+          priv.nixosModules.slopPriv
         ];
       };
     };

--- a/priv/flake.nix
+++ b/priv/flake.nix
@@ -9,7 +9,13 @@
     # deadnix: skip
     nixpkgs,
   }: {
+    # No-ops mirroring the real private overlay's outputs. CI evaluates against
+    # these (--override-input priv ./priv); the deploy override supplies the
+    # real per-host bundles.
     nixosModules = {
+      slopPriv = _: {};
+      nmdPriv = _: {};
+      nsfPriv = _: {};
       stub = _: {};
       hermesPriv = _: {};
       borgKey = _: {};


### PR DESCRIPTION
## Problem

nmd and slop both imported `priv.nixosModules.stub`, which the private overlay aliases to slop's agent-secrets module. One name, two meanings:

- **nmd** inherits slop's credentials — but it is not a recipient of `secrets.yaml`, so its next auto-upgrade **fails at activation** on decrypt.
- **nmd** has no slot for its own private services (currently living in a local checkout).
- **slop** would inherit nmd's services if those moved into the shared repo.

## Change

Each host imports its own bundle from the private overlay:

| Host | Bundle | Contents |
| --- | --- | --- |
| nmd | `nmdPriv` | sops bootstrap + borg key + nmd's services |
| nsf | `nsfPriv` | sops bootstrap + borg key |
| slop | `slopPriv` | sops bootstrap + agent credentials |

`borgKey` folds into the nmd/nsf bundles, so its separate import is dropped. The public `priv/` stub gains matching no-ops so CI (`--override-input priv ./priv`) still evaluates.

**Security property:** nmd and nsf gain sops *functionality* without gaining the agent's *credentials* — the bundles are disjoint, and per-secret `sopsFile` keeps each host limited to files it is a recipient of.

## Deploy ordering

Requires the matching private-overlay change (`homelab/nixos-config-priv` PR #7, currently WIP). **Deploy priv-first** — this PR references `nmdPriv`/`nsfPriv`/`slopPriv`, which only exist once that merges. nmd stays broken until both land.

## Verification

- Gates green locally: alejandra, deadnix, statix.
- Eval against the stub relies on CI's `nix flake check` (no nix daemon in the agent container).
